### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ server = Stretcher::Server.new('http://localhost:9200')
 # Delete an index (in case you already have this one)
 server.index(:foo).delete rescue nil
 # Create an index
-server.index(:foo).create(mapping: {tweet: {properties: {text: 'string'}}})
+server.index(:foo).create(mappings: {tweet: {properties: {text: 'string'}}})
 # Add a document
 server.index(:foo).type(:tweet).put(123, {text: 'Hello'})
 # Retrieve a document


### PR DESCRIPTION
Actually, ES wants a params named `mappings` and not `mapping`.

See:
http://www.elasticsearch.org/guide/reference/api/admin-indices-create-index.html

Signed-off-by: chatgris jboyer@af83.com
