### PR TITLE
fix bug when selecting which fields to load

### DIFF
--- a/lib/stretcher/search_results.rb
+++ b/lib/stretcher/search_results.rb
@@ -19,7 +19,7 @@ module Stretcher
       self.total = raw.hits.total
       self.facets = raw.facets
       self.results = raw.hits.hits.collect {|r|
-        r['_source'].merge({"_id" => r['_id']})
+        (r.has_key?('_source') ? r['_source'] : r['fields']).merge({"_id" => r['_id']})
       }
     end
   end

--- a/spec/lib/stretcher_index_type_spec.rb
+++ b/spec/lib/stretcher_index_type_spec.rb
@@ -26,6 +26,11 @@ describe Stretcher::Index do
       res = type.search({}, {query: {match: {message: match_text}}})
       res.results.first.message.should == @doc[:message]
     end
+
+    it "should build results when _source is not included in loaded fields" do
+      res = type.search({}, {query: {match_all: {}}, fields: ['message']})
+      res.results.first.message.should == @doc[:message]
+    end
   end
 
   describe "put/get" do


### PR DESCRIPTION
Hi,

When querying and selecting fields, the user might not select the "_source" field.
