### PR TITLE
Search Results

### DIFF
--- a/lib/stretcher/es_component.rb
+++ b/lib/stretcher/es_component.rb
@@ -4,9 +4,9 @@ module Stretcher
 
     # Many of the methods marked protected are called by one line shims in subclasses. This is mostly to facilitate
     # better looking rdocs
-    
+
     private
-    
+
     def do_search(generic_opts={}, explicit_body=nil)
       query_opts = {}
       body = nil
@@ -21,7 +21,7 @@ module Stretcher
       response = request(:get, "_search", query_opts) do |req|
         req.body = body
       end
-      SearchResults.new(:raw => response)      
+      SearchResults.new(:raw => response)
     end
 
     def do_refresh

--- a/lib/stretcher/index.rb
+++ b/lib/stretcher/index.rb
@@ -121,7 +121,7 @@ module Stretcher
         req.body = text
       end
     end
-    
+
     # Perform a refresh making all items in this index available instantly
     def refresh
       do_refresh

--- a/lib/stretcher/request_error.rb
+++ b/lib/stretcher/request_error.rb
@@ -2,7 +2,7 @@ module Stretcher
   # Raised when the underlying http status of an operation != 200
   class RequestError < StandardError
     attr_reader :http_response
-    
+
     def initialize(http_response)
       @http_response = http_response
     end

--- a/lib/stretcher/search_results.rb
+++ b/lib/stretcher/search_results.rb
@@ -18,9 +18,11 @@ module Stretcher
       super
       self.total = raw.hits.total
       self.facets = raw.facets
-      self.results = raw.hits.hits.collect {|r|
-        (r.has_key?('_source') ? r['_source'] : r['fields']).merge({"_id" => r['_id']})
-      }
+      self.results = raw.hits.hits.collect do |r|
+        k = ['_source', 'fields'].detect { |k| r.key?(k) }
+        doc = k.nil? ? Hashie::Mash.new : r[k]
+        doc.merge({"_id" => r['_id']})
+      end
     end
   end
 end

--- a/lib/stretcher/server.rb
+++ b/lib/stretcher/server.rb
@@ -119,7 +119,7 @@ module Stretcher
         req.body = text
       end
     end
-    
+
     # Perform a refresh, making all indexed documents available
     def refresh
       do_refresh

--- a/lib/stretcher/util.rb
+++ b/lib/stretcher/util.rb
@@ -3,7 +3,7 @@ module Stretcher
     def self.qurl(url, query_opts=nil)
       query_opts && !query_opts.empty? ? "#{url}?#{querify(query_opts)}" : url
     end
-    
+
     def self.querify(hash)
       hash.map {|k,v| "#{k}=#{v}"}.join('&')
     end

--- a/spec/lib/stretcher_index_spec.rb
+++ b/spec/lib/stretcher_index_spec.rb
@@ -4,7 +4,7 @@ describe Stretcher::Index do
   let(:server) {
     Stretcher::Server.new(ES_URL, :logger => DEBUG_LOGGER)
   }
-  let(:index) { 
+  let(:index) {
     i = server.index('foo')
     i.delete
     server.refresh
@@ -98,7 +98,7 @@ describe Stretcher::Index do
   end
 
   it "execute the analysis API and return an expected result" do
-    analyzed = index.analyze("Candles", :analyzer => :snowball)
+    analyzed = server.index(:foo).analyze("Candles", :analyzer => :snowball)
     analyzed.tokens.first.token.should == 'candl'
   end
 

--- a/spec/lib/stretcher_index_type_spec.rb
+++ b/spec/lib/stretcher_index_type_spec.rb
@@ -2,12 +2,12 @@ require 'spec_helper'
 
 describe Stretcher::IndexType do
   let(:server) { Stretcher::Server.new(ES_URL) }
-  let(:index) { 
+  let(:index) {
     i = server.index(:foo)
     i
   }
-  let(:type) { 
-    t = index.type(:bar) 
+  let(:type) {
+    t = index.type(:bar)
     t.delete_query(:match_all => {})
     index.refresh
     mapping = {"bar" => {"properties" => {"message" => {"type" => "string"}}}}
@@ -39,6 +39,11 @@ describe Stretcher::IndexType do
     it "should build results when _source is not included in loaded fields" do
       res = type.search({}, {query: {match_all: {}}, fields: ['message']})
       res.results.first.message.should == @doc[:message]
+    end
+
+    it "should build results when no document fields are selected" do
+      res = type.search({}, {query: {match_all: {}}, fields: ['_id']})
+      res.results.first.should have_key '_id'
     end
   end
 


### PR DESCRIPTION
Hi,
Bug fix: when issuing a search and not selecting any fields (just asking for ids) ES's response is missing both the fields and the _source keys. Will return mashes with just the '_id'
