### PR TITLE
Add support for HTTP Basic Authentication

### DIFF
--- a/lib/stretcher/server.rb
+++ b/lib/stretcher/server.rb
@@ -30,6 +30,11 @@ module Stretcher
         builder.options[:open_timeout] = 2
       end
 
+      uri_components = URI.parse(@uri)
+      if uri_components.user || uri_components.password
+        @http.basic_auth(uri_components.user, uri_components.password)
+      end
+
       if options[:logger]
         @logger = options[:logger]
       else


### PR DESCRIPTION
To specify a user or a password just add them to the server url using the following syntax http://user:password@example.com:9200.
