### PR TITLE
Handle 410 responses as 404s

### DIFF
--- a/lib/stretcher/server.rb
+++ b/lib/stretcher/server.rb
@@ -151,8 +151,8 @@ module Stretcher
 
       if res.status >= 200 && res.status <= 299
         res.body
-      elsif res.status == 404
-        err_str = "Error 404 processing request: (#{res.status})! #{res.env[:method]} URL: #{res.env[:url]}"
+      elsif [404, 410].include? res.status
+        err_str = "Error processing request: (#{res.status})! #{res.env[:method]} URL: #{res.env[:url]}"
         err_str << "\n Resp Body: #{res.body}"
         raise RequestError::NotFound.new(res), err_str
       else


### PR DESCRIPTION
When using bonsai's elasticsearch, indices return 410 (instead of 404) when they haven't been created yet.
