### PR TITLE
Merge _index and _type into result document

### DIFF
--- a/lib/stretcher/search_results.rb
+++ b/lib/stretcher/search_results.rb
@@ -24,7 +24,7 @@ module Stretcher
         if r.key?('highlight')
           doc.merge!({"_highlight" => r['highlight']})
         end
-        doc.merge!({"_id" => r['_id']})
+        doc.merge!({"_id" => r['_id'], "_index" => r['_index'], "_type" => r['_type']})
       end
     end
   end


### PR DESCRIPTION
My application needs to know the index and type that a document comes from. This adds that information to the search result documents. 
