### PR TITLE
Allow update to support additional parameters

### DIFF
--- a/lib/stretcher/index_type.rb
+++ b/lib/stretcher/index_type.rb
@@ -45,9 +45,7 @@ module Stretcher
     # type.update(987, script: "ctx._source.message = 'Updated!'")
     # See http://www.elasticsearch.org/guide/reference/api/update.html
     def update(id, body, options={})
-      request(:post, "#{id}/_update", options) do |req|
-        req.body = body
-      end
+      request(:post, Util.qurl("#{id}/_update", options), body)
     end
 
     # Deletes the document with the given ID


### PR DESCRIPTION
I want to return `_source` from an update operation. The attached patch doesn't work, however:

``` ruby
index = Stretcher::Server.new.index('foo').type('bar')
index.put('foo', {bar: 'baz'})
index.update('foo', {doc: {bar: 12345}}, :fields => ["_source"])
#<Hashie::Mash _id="foo" _index="foo" _type="bar" _version=2 ok=true>
```

Despite passing in the `fields` option as described in the [update API documentation](http://www.elasticsearch.org/guide/reference/api/update/), the full document _source isn't included. From the command line, however, the full document is returned.

Any ideas?
