### PR TITLE
Merge _score into result document

### DIFF
--- a/lib/stretcher/search_results.rb
+++ b/lib/stretcher/search_results.rb
@@ -24,7 +24,7 @@ module Stretcher
         if r.key?('highlight')
           doc.merge!({"_highlight" => r['highlight']})
         end
-        doc.merge!({"_id" => r['_id'], "_index" => r['_index'], "_type" => r['_type']})
+        doc.merge!({"_id" => r['_id'], "_index" => r['_index'], "_type" => r['_type'], "_score" => r['_score']})
       end
     end
   end

--- a/spec/lib/stretcher_search_results_spec.rb
+++ b/spec/lib/stretcher_search_results_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe Stretcher::SearchResults do
+  let(:result) do
+    Hashie::Mash.new({
+      'raw' => {
+        'facets' => [],
+        'hits' => {
+          'total' => 1,
+          'hits'  => [{
+            '_score' => 255,
+            '_id' => 2,
+            '_index' => 'index_name',
+            '_type' => 'type_name'
+          }]
+        }
+      }
+    })
+  end
+
+  context 'merges in select keys' do
+    subject(:search_result) { Stretcher::SearchResults.new(result).results.first }
+    its(:_score) { should == 255 }
+    its(:_id) { should == 2 }
+    its(:_index) { should == 'index_name' }
+    its(:_type) { should == 'type_name' }
+  end
+end


### PR DESCRIPTION
Hi there,

I have a use case to use the score from ES on the client side, and would like to merge the score into the document.

I added some tests around the search_result since previously there were none.

Please let me know if you have any questions or feedback.

Thanks,

Dan
