### PR TITLE
Add mget on index type

### DIFF
--- a/lib/stretcher/index_type.rb
+++ b/lib/stretcher/index_type.rb
@@ -23,6 +23,14 @@ module Stretcher
       raw ? res : res["_source"]
     end
 
+    # Retrieves multiple documents of the index type by ID
+    # http://www.elasticsearch.org/guide/reference/api/multi-get/
+    def mget(ids)
+      request(:get, '_mget') do |req|
+        req.body = {ids: ids}
+      end
+    end
+
     # Explains a query for a specific document
     def explain(id, query)
       request(:get, "#{id}/_explain") do |req|

--- a/spec/lib/stretcher_index_type_spec.rb
+++ b/spec/lib/stretcher_index_type_spec.rb
@@ -53,6 +53,22 @@ describe Stretcher::IndexType do
     end
   end
 
+  describe 'mget' do
+    let(:doc_one) {{:message => "message one!", :_timestamp => 1366420402}}
+    let(:doc_two) {{:message => "message two!", :_timestamp => 1366420403}}
+
+    before do
+      type.put(988, doc_one)
+      type.put(989, doc_two)
+    end
+
+    it 'fetches multiple documents by id' do
+      type.mget([988, 989]).docs.count.should == 2
+      type.mget([988, 989]).docs.first._source.message.should == 'message one!'
+      type.mget([988, 989]).docs.last._source.message.should == 'message two!'
+    end
+  end
+
   describe "put/get/delete/explain" do
     before do
       @doc = {:message => "hello!", :_timestamp => 1366420401}


### PR DESCRIPTION
Hi there!

This commit adds an mget method on the index type model, which then allows you to pass an array of IDs to mget and get back those documents.

It's a bit easier to use and cleaner than the mget that's on server, since it's more specific and requires you to pass less metadata about indexes and types. As a result, I feel it's a nice addition to the stretcher API.

Please let me know if you have any questions or concerns!

Thanks,

Dan
