### PR TITLE
Adding GET /_aliases capability

### DIFF
--- a/lib/stretcher/server.rb
+++ b/lib/stretcher/server.rb
@@ -129,9 +129,13 @@ module Stretcher
     # Ex:
     # server.aliases({actions: {add: {index: :my_index, alias: :my_alias}}})
     # as per: http://www.elasticsearch.org/guide/reference/api/admin-indices-aliases.html
-    def aliases(body)
-      request(:post, path_uri("/_aliases")) do |req|
-        req.body = body
+    def aliases(body=nil)
+      if body
+        request(:post, path_uri("/_aliases")) do |req|
+          req.body = body
+        end
+      else
+        request(:get, path_uri("/_aliases"))
       end
     end
 

--- a/spec/lib/stretcher_server_spec.rb
+++ b/spec/lib/stretcher_server_spec.rb
@@ -34,6 +34,8 @@ describe Stretcher::Server do
     server.aliases(:actions => [{:add => {:index => :foo, :alias => :foo_alias}}])
 
     server.index(:foo_alias).get_settings.should == server.index(:foo).get_settings
+
+    server.aliases[:foo][:aliases].keys.should include 'foo_alias'
   end
 
   it "should check the status w/o error" do


### PR DESCRIPTION
If `Server#aliases` is call without `body`, then it is interpreted as a `GET /_aliases` request that returns a hash in the format of index name => aliases.

See "Retrieving existing aliases" section of http://www.elasticsearch.org/guide/reference/api/admin-indices-aliases/
