### PR TITLE
Correctly pass through the 'fields' options when using the 'get' operation.

### DIFF
--- a/lib/stretcher/index_type.rb
+++ b/lib/stretcher/index_type.rb
@@ -20,7 +20,7 @@ module Stretcher
         options = {}
       end
       res = request(:get, id, options)
-      raw ? res : res["_source"]
+      raw ? res : (res["_source"] || res["fields"])
     end
 
     # Retrieves multiple documents of the index type by ID

--- a/spec/lib/stretcher_index_type_spec.rb
+++ b/spec/lib/stretcher_index_type_spec.rb
@@ -94,9 +94,9 @@ describe Stretcher::IndexType do
     end
 
     it "should get individual, passing through additional options" do
-      res = type.get(987, {:fields => ['_timestamp']})
+      res = type.get(987, {:fields => '_timestamp'})
       res._timestamp.should == @doc[:_timestamp]
-      res.message == nil
+      res.message.should == nil
     end
 
     it "should get individual raw documents correctly" do


### PR DESCRIPTION
The spec, in this case, was not in fact correctly asserting that the fields operation had correctly pruned unnamed fields.

The API could have been implemented as :fields => ['a', 'b'] or :fields => 'a,b'.

I chose the latter, as it reflects the syntax of the HTTP request to elasticsearch, and the former would require a special translation somewhere to get it into the syntax of the latter by the time it got to the HTTP request anyway.

I guess this API decision is not a typical Ruby multi-value idiom, but the theme of this library is to err on the side of tightly mapping to the elasticsearch API, and it adds the least complexity to the code, so in my mind it makes sense.
