### PR TITLE
Allow _routing metadata to be used with index.bulk_index

### DIFF
--- a/lib/stretcher/index.rb
+++ b/lib/stretcher/index.rb
@@ -26,14 +26,19 @@ module Stretcher
     #
     #    docs = [{"_type" => "tweet", "_id" => 91011, "text" => "Bulked"}]
     #    server.index(:foo).bulk_index(docs)
-    def bulk_index(documents)
-      @server.bulk documents.reduce("") {|post_data, d_raw|
+    def bulk_index(documents, options={})
+      body = documents.reduce("") {|post_data, d_raw|
         d = Hashie::Mash.new(d_raw)
-        action_meta = {"index" => {"_index" => name, "_type" => d["_type"], "_id" => d["_id"] || d["id"]}}
-        action_meta["index"]["_parent"] = d["_parent"] if d["_parent"]
-        post_data << (action_meta.to_json + "\n")
+        index_meta = { :_index => name, :_id => (d.delete(:id) || d.delete(:_id)) }
+        
+        d.keys.reduce(index_meta) do |memo, key|
+          index_meta[key] = d.delete(key) if key.to_s.start_with?('_')
+        end
+
+        post_data << ({:index => index_meta}.to_json + "\n")
         post_data << (d.to_json + "\n")
       }
+      @server.bulk body, options
     end
 
     # Creates the index, with the supplied hash as the optinos body (usually mappings: and settings:))

--- a/lib/stretcher/server.rb
+++ b/lib/stretcher/server.rb
@@ -95,8 +95,8 @@ module Stretcher
     
     # Perform a raw bulk operation. You probably want to use Stretcher::Index#bulk_index
     # which properly formats a bulk index request.
-    def bulk(data)
-      request(:post, path_uri("/_bulk"),{}, data)
+    def bulk(data, options={})
+      request(:post, path_uri("/_bulk"), options, data)
     end
 
     # Retrieves stats for this server


### PR DESCRIPTION
Just a feature I need.  Currently adding explicit routing metadata to a bulk_index action is not possible.
