### PR TITLE
Whitelist bulk metadata fields to ensure that underscored attributes that are not system attributes make it through with bulk_index

### DIFF
--- a/lib/stretcher/index.rb
+++ b/lib/stretcher/index.rb
@@ -44,9 +44,10 @@ module Stretcher
       body = documents.reduce("") {|post_data, d_raw|
         d = Hashie::Mash.new(d_raw)
         index_meta = { :_index => name, :_id => (d.delete(:id) || d.delete(:_id)) }
-        
+
+        system_fields = %w{_type _parent _routing}
         d.keys.reduce(index_meta) do |memo, key|
-          index_meta[key] = d.delete(key) if key.to_s.start_with?('_')
+          index_meta[key] = d.delete(key) if system_fields.include?(key.to_s)
         end
 
         post_data << ({action => index_meta}.to_json + "\n")
@@ -94,7 +95,7 @@ module Stretcher
     rescue Stretcher::RequestError::NotFound
       false
     end
-    
+
     # Delete documents by a given query.
     # Per: http://www.elasticsearch.org/guide/reference/api/delete-by-query.html
     def delete_query(query)

--- a/spec/lib/stretcher_index_spec.rb
+++ b/spec/lib/stretcher_index_spec.rb
@@ -23,10 +23,11 @@ describe Stretcher::Index do
     i
   }
   let(:corpus) {
+    # underscore field that are not system fields should make it through to _source
     [
-     {:text => "Foo", "_type" => 'tweet', "_id" => 'fooid'},
-     {:text => "Bar", "_type" => 'tweet', "_id" => 'barid'},
-     {:text => "Baz", "_type" => 'tweet', "id" => 'bazid'} # Note we support both _id and id
+     {:text => "Foo", :_text => '_Foo', "_type" => 'tweet', "_id" => 'fooid'},
+     {:text => "Bar", :_text => '_Bar', "_type" => 'tweet', "_id" => 'barid'},
+     {:text => "Baz", :_text => '_Baz', "_type" => 'tweet', "id" => 'bazid'} # Note we support both _id and id
     ]
   }
 
@@ -81,6 +82,7 @@ describe Stretcher::Index do
       corpus.each {|doc|
         fetched_doc = index.type(doc["_type"]).get(doc["_id"] || doc["id"], {}, true)
         fetched_doc._source.text.should == doc[:text]
+        fetched_doc._source._text.should == doc[:_text]
         fetched_doc._source._id.should be_nil
         fetched_doc._source._type.should be_nil
       }


### PR DESCRIPTION
I have a use case to have documents with fields that start with an underscore, but bulk_index currently doesn't allow it.
