### PR TITLE
Support customizing result class from Hashie::Mash to something else.

### DIFF
--- a/lib/stretcher/search_results.rb
+++ b/lib/stretcher/search_results.rb
@@ -33,6 +33,9 @@ module Stretcher
       self.results = raw.hits.hits.collect do |r|
         k = ['_source', 'fields'].detect { |k| r.key?(k) }
         doc = k.nil? ? SearchResults.result_class.new : r[k]
+        if doc.class != SearchResults.result_class
+          doc = SearchResults.result_class.new(doc)
+        end
         if r.key?('highlight')
           doc.merge!({"_highlight" => r['highlight']})
         end

--- a/spec/lib/stretcher_search_results_spec.rb
+++ b/spec/lib/stretcher_search_results_spec.rb
@@ -20,6 +20,24 @@ describe Stretcher::SearchResults do
     })
   end
 
+  let(:result_with_source) do
+    Hashie::Mash.new({
+      'raw' => {
+        'facets' => [],
+        'hits' => {
+          'total' => 1,
+          'hits'  => [{
+            '_source' => { 'blah' => 'dummy_field' },
+            '_score' => 255,
+            '_id' => 2,
+            '_index' => 'index_name',
+            '_type' => 'type_name'
+          }]
+        }
+      }
+    })
+  end
+
   context 'merges in select keys' do
     subject(:search_result) { Stretcher::SearchResults.new(result).results.first }
     its(:_score) { should == 255 }
@@ -32,6 +50,14 @@ describe Stretcher::SearchResults do
     subject(:search_result) do
       Stretcher::SearchResults.result_class = CustomResultClass
       Stretcher::SearchResults.new(result).results.first
+    end
+    its(:class) { should == CustomResultClass }
+  end
+
+  context 'use custom result class when _source is defined' do
+    subject(:search_result) do
+      Stretcher::SearchResults.result_class = CustomResultClass
+      Stretcher::SearchResults.new(result_with_source).results.first
     end
     its(:class) { should == CustomResultClass }
   end


### PR DESCRIPTION
Change to allow changing class of search result class from Hashie::Mash to something else via Stretcher::SearchResults.result_class attribute.

Convenient when you'd like to be able to add methods to search results without having to deep-copy/re-create the whole result list.

Added code and rspec test.
