### PR TITLE
Improve Stretcher::SearchResults to be more lazy

### DIFF
--- a/lib/stretcher/es_component.rb
+++ b/lib/stretcher/es_component.rb
@@ -18,7 +18,7 @@ module Stretcher
       response = request(:get, "_search", query_opts) do |req|
         req.body = body
       end
-      SearchResults.new(:raw => response)
+      SearchResults.new(response)
     end
 
     def do_refresh

--- a/lib/stretcher/search_results.rb
+++ b/lib/stretcher/search_results.rb
@@ -8,24 +8,83 @@ module Stretcher
   # * total : The total number of matched docs
   # * facets : the facets hash
   # * results : The hit results with _id merged in to _source
-  class SearchResults < Hashie::Dash
-    property :raw, :required => true
-    property :total
-    property :facets
-    property :results
+  class SearchResults
+    def initialize(raw)
+      @raw_plain = raw
+    end
+    
+    # Returns a plain (string keyed) hash of the raw response
+    def raw_plain
+      @raw_plain
+    end
 
-    def initialize(*args)
-      super
-      self.total = raw.hits.total
-      self.facets = raw.facets
-      self.results = raw.hits.hits.collect do |r|
-        k = ['_source', 'fields'].detect { |k| r.key?(k) }
-        doc = k.nil? ? Hashie::Mash.new : r[k]
-        if r.key?('highlight')
-          doc.merge!({"_highlight" => r['highlight']})
-        end
-        doc.merge!({"_id" => r['_id'], "_index" => r['_index'], "_type" => r['_type'], "_score" => r['_score']})
+    # Returns a Hashie::Mash version of the raw response
+    def raw
+      @raw ||= Hashie::Mash.new(@raw_plain)
+    end
+    
+    # Returns the total number of results
+    def total
+      @total ||= raw_plain['hits']['total']
+    end
+
+    def facets
+      @facets ||= raw[:facets]
+    end    
+
+    # DEPRECATED!
+    # Call #documents instead!
+    def results
+      pretty
+    end
+  
+    # Returns a 'prettier' version of elasticsearch results
+    # This will:
+    # 
+    # 1. Return either '_source' or 'fields' as the base of the result
+    # 2. Merge any keys beginning with a '_' into it as well (such as '_score')
+    # 3. Copy the 'highlight' field into '_highlight'
+    #
+    def pretty
+      # This function and its helpers are side-effecty for speed
+      @documents ||= raw[:hits][:hits].map do |hit|
+        doc = extract_source(hit)
+        copy_underscores(hit, doc)
+        copy_highlight(hit, doc)
+        doc
       end
+    end
+    
+    private
+    
+    def extract_source(hit)
+      # Memoize the key, since it will be uniform across results
+      @doc_key ||= if hit.key?(:_source)
+                     :_source
+                   elsif hit.key?(:fields)
+                     :fields
+                   else
+                     nil
+                   end
+      
+      Hashie::Mash.new(@doc_key ? hit[@doc_key] : Hashie::Mash.new)      
+    end
+
+    def copy_underscores(hit, doc)
+      # Copy underscore keys into the document
+      hit.each do |k,v|
+        if k && k[0] == "_"
+          doc[k] = v
+        end
+      end
+      doc
+    end
+
+    def copy_highlight(hit, doc)
+      if highlight = hit.key?("highlight")
+        doc[:_highlight] = highlight
+      end
+      doc
     end
   end
 end

--- a/lib/stretcher/server.rb
+++ b/lib/stretcher/server.rb
@@ -146,7 +146,7 @@ module Stretcher
         raise RequestError.new(res), "Could not msearch #{errors.inspect}"
       end
 
-      res['responses'].map {|r| SearchResults.new(:raw => r)}
+      res['responses'].map {|r| SearchResults.new(r)}
     end
 
     # Retrieves multiple documents, possibly from multiple indexes

--- a/spec/lib/stretcher_index_spec.rb
+++ b/spec/lib/stretcher_index_spec.rb
@@ -4,24 +4,7 @@ describe Stretcher::Index do
   let(:server) {
     Stretcher::Server.new(ES_URL, :logger => DEBUG_LOGGER)
   }
-  let(:index) {
-    i = server.index('foo')
-    begin
-      i.delete
-    rescue Stretcher::RequestError::NotFound
-    end
-    server.refresh
-    i.create({
-      :settings => {
-        :number_of_shards => 1,
-        :number_of_replicas => 0
-      }
-    })
-    # Why do both? Doesn't hurt, and it fixes some races
-    server.refresh
-    i.refresh
-    i
-  }
+  let(:index) { ensure_test_index(server, :foo) }
   let(:corpus) {
     # underscore field that are not system fields should make it through to _source
     [

--- a/spec/lib/stretcher_index_type_spec.rb
+++ b/spec/lib/stretcher_index_type_spec.rb
@@ -2,8 +2,7 @@ require 'spec_helper'
 
 describe Stretcher::IndexType do
   let(:server) { Stretcher::Server.new(ES_URL, :logger => DEBUG_LOGGER) }
-  let(:index) { server.index(:foo) }
-  
+  let(:index) { ensure_test_index(server, :foo) }
   let(:type) {  index.type(:bar) }
 
   it "should be existentially aware" do
@@ -46,8 +45,8 @@ describe Stretcher::IndexType do
 
     it "should add _highlight field to resulting documents when present" do
       res = type.search(:query => {:match => {:message => 'hello'}}, :highlight => {:fields => {:message => {}}})
-      res.results.first.message.should == @doc[:message]
-      res.results.first.should have_key '_highlight'
+      res.pretty.first.message.should == @doc[:message]
+      res.pretty.first.should have_key '_highlight'
     end
   end
 

--- a/spec/lib/stretcher_search_results_spec.rb
+++ b/spec/lib/stretcher_search_results_spec.rb
@@ -3,23 +3,24 @@ require 'spec_helper'
 describe Stretcher::SearchResults do
   let(:result) do
     Hashie::Mash.new({
-      'raw' => {
-        'facets' => [],
-        'hits' => {
-          'total' => 1,
-          'hits'  => [{
-            '_score' => 255,
-            '_id' => 2,
-            '_index' => 'index_name',
-            '_type' => 'type_name'
-          }]
-        }
-      }
-    })
+                       'facets' => [],
+                       'hits' => {
+                         'total' => 1,
+                         'hits'  => [{
+                                       '_score' => 255,
+                                       '_id' => 2,
+                                       '_index' => 'index_name',
+                                       '_type' => 'type_name'
+                                     }]
+                       }
+                     })
   end
 
   context 'merges in select keys' do
-    subject(:search_result) { Stretcher::SearchResults.new(result).results.first }
+    subject(:search_result) {
+      Stretcher::SearchResults.new(result).pretty.first
+    }
+    
     its(:_score) { should == 255 }
     its(:_id) { should == 2 }
     its(:_index) { should == 'index_name' }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,3 +8,22 @@ File.open("test_logs", 'wb') {|f| f.write("")}
 DEBUG_LOGGER = Logger.new('test_logs')
 ES_URL = 'http://localhost:9200'
 require File.expand_path(File.join(File.dirname(__FILE__), %w[.. lib stretcher]))
+
+def ensure_test_index(server, name)
+  i = server.index(name)
+  begin
+    i.delete
+  rescue Stretcher::RequestError::NotFound
+  end
+  server.refresh
+  i.create({
+             :settings => {
+               :number_of_shards => 1,
+               :number_of_replicas => 0
+             }
+           })
+  # Why do both? Doesn't hurt, and it fixes some races
+  server.refresh
+  i.refresh
+  i
+end


### PR DESCRIPTION
In this patch Stretcher::SearchResults fixes a number of the issues brought up in  #49 and #59 . The concerns people had were:
- Accessing raw, unmodified search responses (no special copying of _ prefixed names)
- Accessing raw unmodified data w/o hashie mashification
- The #results method is poorly named, I've provided a better alias, #documents

To fix this the following changes were made
- The new #documents method is now lazy, it will only construct the fancy version of the response if invoked. 
- The #raw method is now a lazy way to return the server response as a Hashie::Mash
- The new #raw_plain method returns the server response as a standard ruby Hash
- The code has been DRYed up in general
