### PR TITLE
Moved bulk operations to index level to better support hosted elasticsearch services

### DIFF
--- a/lib/stretcher/index.rb
+++ b/lib/stretcher/index.rb
@@ -54,7 +54,7 @@ module Stretcher
       
       body = documents.reduce("") {|post_data, d_raw|
         d = Hashie::Mash.new(d_raw)
-        index_meta = { :_index => name, :_id => (d[:id] || d.delete(:_id)) }
+        index_meta = { :_id => (d[:id] || d.delete(:_id)) }
 
         system_fields = %w{_type _parent _routing}
         d.keys.reduce(index_meta) do |memo, key|
@@ -65,7 +65,7 @@ module Stretcher
         post_data << (MultiJson.dump(d) << "\n") unless action == :delete
         post_data
       }
-      @server.bulk body, options
+      bulk body, options
     end
 
     # Creates the index, with the supplied hash as the options body (usually mappings: and settings:))
@@ -185,6 +185,12 @@ module Stretcher
     # http://www.elasticsearch.org/guide/reference/api/percolate/
     def delete_percolator_query(query_name)
       server.request(:delete, percolator_query_path(query_name))
+    end
+    
+    # Perform a raw bulk operation. You probably want to use Stretcher::Index#bulk_index
+    # which properly formats a bulk index request.
+    def bulk(data, options={})
+      request(:post, "_bulk", options, data)
     end
 
     # Full path to this index


### PR DESCRIPTION
I moved bulk operations to the index level. Instead of calling http://server/_bulk it now calls http://server/index/_bulk. 

The reason for this change is to support hosted elasticsearch services, which sometimes do not allow calls at the server level (indexdepot.com for example). 

All specs pass without a change. I left the Server#bulk method in, just in case anybody is using it directly.
