### PR TITLE
remove deprectated jruby-json gem dependency

### DIFF
--- a/stretcher.gemspec
+++ b/stretcher.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |gem|
 
   if RUBY_PLATFORM == 'java'
     gem.add_runtime_dependency('jruby-openssl')
-    gem.add_runtime_dependency('json-jruby')
   end
 
   if RUBY_VERSION < "1.9"


### PR DESCRIPTION
The jruby-json gem is deprecated. It's now part of the json gem (see https://github.com/mernen/json-jruby). 
Builds on Travis and works for me without an explicit dependency.
