### PR TITLE
Use correct Faraday timeout option name when creating the http client.

### DIFF
--- a/lib/stretcher/server.rb
+++ b/lib/stretcher/server.rb
@@ -11,7 +11,7 @@ module Stretcher
 
         builder.request :multi_json
 
-        builder.options[:read_timeout] = options[:read_timeout] || 30
+        builder.options[:timeout] = options[:read_timeout] || 30
         builder.options[:open_timeout] = options[:open_timeout] || 2
 
         if faraday_configurator = options[:faraday_configurator]

--- a/spec/lib/stretcher_server_spec.rb
+++ b/spec/lib/stretcher_server_spec.rb
@@ -17,6 +17,13 @@ describe Stretcher::Server do
     server = Stretcher::Server.new(ES_URL, :log_level => :info)
     server.logger.level.should == Logger::INFO
   end
+  
+  it 'sets timeouts from options' do
+    server = Stretcher::Server.new(ES_URL, :read_timeout => 5, :open_timeout => 2)
+    puts server.http.options.inspect
+    server.http.options[:timeout].should == 5
+    server.http.options[:open_timeout].should == 2
+  end
 
   it "should support the block friendly 'with_server'" do
     exposed = nil


### PR DESCRIPTION
Faraday uses the option name :timeout to specify read timeouts instead of :read_timeout. This code keeps the same interface for Stretcher (:read_timeout) but translates it to :timeout so the HTTP client gets the correct value. Otherwise the read timeout is not set by Stretcher and the client default is used.
