### PR TITLE
Fixed non-ruby 1.8 compatible hash in alias.rb

### DIFF
--- a/lib/stretcher/alias.rb
+++ b/lib/stretcher/alias.rb
@@ -27,8 +27,8 @@ module Stretcher
     def create(options = {})
       request(:put) do |req|
         req.body = {
-          actions: [
-            add: options.merge(:alias => @name)
+          :actions => [
+            :add => options.merge(:alias => @name)
           ]
         }
       end


### PR DESCRIPTION
We currently use Stretcher 1.19.0 on our ruby 1.8.7 rails app. 

A ruby 1.9 hash crept into the latest version - this pull request should make it 1.8.7 friendly again.
