### PR TITLE
Adds support for multiple hosts

### DIFF
--- a/lib/stretcher/server.rb
+++ b/lib/stretcher/server.rb
@@ -79,6 +79,7 @@ module Stretcher
     def initialize(uri='http://localhost:9200', options={})
       @request_mtx = Mutex.new
       @uri = uri.to_s
+      @uri = uri.sample.to_s if uri.is_a? Array
       @uri_components = URI.parse(@uri)
       @http = self.class.build_client(@uri_components, options)
       @logger = self.class.build_logger(options)

--- a/spec/lib/stretcher_server_spec.rb
+++ b/spec/lib/stretcher_server_spec.rb
@@ -13,6 +13,12 @@ describe Stretcher::Server do
     server.class.should == Stretcher::Server
   end
 
+  it "should allow multiple uris on initialize" do
+    uris   = %w(http://localhost:9200 http://localhost:9201)
+    server = Stretcher::Server.new(uris, :log_level => :info)
+    server.uri.should_not be_nil
+  end
+
   it 'sets log level from options' do
     server = Stretcher::Server.new(ES_URL, :log_level => :info)
     server.logger.level.should == Logger::INFO


### PR DESCRIPTION
Sometimes we want to round robin requests between multiple servers.
Pyes supports this as well:
https://github.com/aparo/pyes/blob/master/pyes/connection.py#L58
