### PR TITLE
Fix SearchResults#raw_plain so that it returns a plain ruby Hash.

### DIFF
--- a/lib/stretcher/es_component.rb
+++ b/lib/stretcher/es_component.rb
@@ -15,7 +15,7 @@ module Stretcher
         body = generic_opts
       end
 
-      response = request(:get, "_search", query_opts) do |req|
+      response = request(:get, "_search", query_opts, nil, {}, :mashify => false) do |req|
         req.body = body
       end
       SearchResults.new(response)
@@ -25,10 +25,10 @@ module Stretcher
       request(:post, "_refresh")
     end
 
-    def request(method, path=nil, params={}, body=nil, headers={}, &block)
+    def request(method, path=nil, params={}, body=nil, headers={}, options={}, &block)
       prefixed_path = path_uri(path)
       raise "Cannot issue request, no server specified!" unless @server
-      @server.request(method, prefixed_path, params, body, headers, &block)
+      @server.request(method, prefixed_path, params, body, headers, options, &block)
     end
 
     def do_delete_query(query)

--- a/lib/stretcher/index_type.rb
+++ b/lib/stretcher/index_type.rb
@@ -85,7 +85,7 @@ module Stretcher
     # See http://www.elasticsearch.org/guide/reference/api/more-like-this/ for more
     # Takens an options hash as a second argument, for things like fields=
     def mlt(id, options={})
-      SearchResults.new(request(:get, "#{id}/_mlt", options))
+      SearchResults.new(request(:get, "#{id}/_mlt", options, nil, {}, :mashify => false))
     end
 
     # Retrieve the mapping for this type

--- a/spec/lib/stretcher_index_spec.rb
+++ b/spec/lib/stretcher_index_spec.rb
@@ -235,7 +235,7 @@ describe Stretcher::Index do
 
     context "with no options" do
       it "calls request for the correct endpoint with empty options" do
-        expect(index.server).to receive(:request).with(:post, request_url, nil, nil, {})
+        expect(index.server).to receive(:request).with(:post, request_url, nil, nil, {}, {})
         index.optimize
       end
 
@@ -246,7 +246,7 @@ describe Stretcher::Index do
 
     context "with options" do
       it "calls request for the correct endpoint with options passed" do
-        expect(index.server).to receive(:request).with(:post, request_url, {"max_num_segments" => 1}, nil, {})
+        expect(index.server).to receive(:request).with(:post, request_url, {"max_num_segments" => 1}, nil, {}, {})
         index.optimize("max_num_segments" => 1)
       end
 

--- a/spec/lib/stretcher_search_results_spec.rb
+++ b/spec/lib/stretcher_search_results_spec.rb
@@ -1,6 +1,11 @@
 require 'spec_helper'
 
 describe Stretcher::SearchResults do
+  let(:server) {
+    Stretcher::Server.new(ES_URL, :logger => DEBUG_LOGGER)
+  }
+  let(:index) { ensure_test_index(server, :foo) }
+
   let(:result) do
     Hashie::Mash.new({
                        'facets' => [],
@@ -52,5 +57,19 @@ describe Stretcher::SearchResults do
 
     its(:_id) { should == 2 }
     its(:_highlight) { should == {'message.*' => ["meeting at <hit>protonet</hit>!"]} }
+  end
+
+  context 'result object types' do
+    let(:search_result) {
+      index.search(:query => {:match_all => {}})
+    }
+
+    it 'returns a plain hash for raw_plain' do
+      search_result.raw_plain.should be_instance_of(::Hash)
+    end
+
+    it 'returns a hashie mash for raw' do
+      search_result.raw.should be_instance_of(Hashie::Mash)
+    end
   end
 end


### PR DESCRIPTION
Based on #61, I believe the intention was for `SearchResults#raw_plain` to return a plain ruby Hash. However, the `raw_plain` method still seems to be returning a `Hashie::Mash` object, and not a plain ruby Hash. This is due to the [mashify middleware enabled in Faraday for all the requests](https://github.com/PoseBiz/stretcher/blob/v1.21.0/lib/stretcher/server.rb#L9). This is causing all the HTTP responses to become `Hashie::Mash` objects before `SearchResults` even gets the response.

Simply disabling the mashify middleware fixes this, but also breaks a number of other specs, since other classes are expecting Hashie::Mash responses. This pull request fixes it by making the default mashification of the each response optional. It defaults to true to maintain backwards compatibility, but disables it on requests where `SearchResults` will be generated from the response. I'm not entirely sure this is the best way to fix, this, but it's the simplest way I could figure while maintaining backwards compatibility.

And for what it's worth, having the ability to access a plain ruby hash instead creating the Hashie::Mash object does yield significant speed ups when dealing with large responses, so it would be nice to have a way to skip the Mash creation as I believe `raw_plain` was intended to provide.
