### PR TITLE
Add method to access ES aggregations data

### DIFF
--- a/lib/stretcher/search_results.rb
+++ b/lib/stretcher/search_results.rb
@@ -35,6 +35,12 @@ module Stretcher
       @facets ||= raw[:facets]
     end
 
+    # Returns the aggregations data from elasticsearch
+    def aggs
+      @aggs ||= raw[:aggregations]
+    end
+    alias_method :aggregations, :aggs
+
     # Returns a 'prettier' version of elasticsearch results
     # Also aliased as +docs+
     # This will:


### PR DESCRIPTION
Elasticsearch transitions from facets to aggregations.

Add a simple accessor to the aggregations data.

Example usage:

```
Stretcher::Server.with_server(url) do |s|
  s.index(index).search(
    :aggs   => {
      :visits_over_time => {
        :date_histogram => {
          :field => :time, :interval => :second
        }
      }
    }
).aggregations
```

Results:

```
#<Hashie::Mash visits_over_time=#<Hashie::Mash buckets=[#<Hash...
```
